### PR TITLE
Add required OIDC role authentication permission

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -32,6 +32,8 @@ jobs:
   release:
     if: github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'released')
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # To use OIDC role authentication in aws-actions/configure-aws-credentials
     needs: [build]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
`id-token: write` permissions is required to use OIDC authentication