### PR TITLE
fix: Handle pagination in chains API to fetch all chains

### DIFF
--- a/src/api/getChains.tsx
+++ b/src/api/getChains.tsx
@@ -8,11 +8,17 @@ async function getChains(
   configServiceBaseUrl: string,
   options?: RawAxiosRequestConfig,
 ): Promise<chain[]> {
-  const endpoint = `${configServiceBaseUrl}${CHAINS_PATHNAME}`;
+  let allChains: chain[] = [];
+  let nextUrl: string | null = `${configServiceBaseUrl}${CHAINS_PATHNAME}`;
 
-  const { data } = await axios.get(endpoint, options);
+  while (nextUrl) {
+    const { data } = await axios.get(nextUrl, options);
 
-  return data.results;
+    allChains = allChains.concat(data.results);
+    nextUrl = data.next;
+  }
+
+  return allChains;
 }
 
 export default getChains;

--- a/src/api/getChains.tsx
+++ b/src/api/getChains.tsx
@@ -4,15 +4,29 @@ import chain from "src/models/chain";
 
 const CHAINS_PATHNAME = "/api/v1/chains/";
 
+interface ChainsApiResponse {
+  results: chain[];
+  next: string | null;
+}
+
 async function getChains(
   configServiceBaseUrl: string,
   options?: RawAxiosRequestConfig,
 ): Promise<chain[]> {
-  const endpoint = `${configServiceBaseUrl}${CHAINS_PATHNAME}`;
+  let allChains: chain[] = [];
+  let nextUrl: string | null = `${configServiceBaseUrl}${CHAINS_PATHNAME}`;
 
-  const { data } = await axios.get(endpoint, options);
+  while (nextUrl) {
+    const { data }: { data: ChainsApiResponse } = await axios.get(
+      nextUrl,
+      options,
+    );
 
-  return data.results;
+    allChains = allChains.concat(data.results);
+    nextUrl = data.next;
+  }
+
+  return allChains;
 }
 
 export default getChains;


### PR DESCRIPTION
## 📝 Summary

Fixes pagination handling in the chains API to fetch all available chains from the Safe Config Service.

## 🐛 Problem

The Safe Config Service API (`https://safe-config.safe.global/api/v1/chains/`) returns paginated results with a default limit of 40 chains per page. The current implementation only fetched the first page, which meant:
- Only 40 out of 41 available chains were displayed
- Any future additions beyond the initial page would not be loaded

## ✅ Solution

Updated the `getChains` function to handle pagination properly by:
- Implementing a `while` loop that iterates through all pages
- Following the `next` URL from each response until it becomes `null`
- Concatenating all results into a single array before returning

## 🔍 Changes

**File: `src/api/getChains.tsx`**
- Added pagination loop to fetch all pages
- Concatenate results from each page into `allChains` array
- Continue fetching until `next` is `null`

## 🧪 Testing

- [x] Verified all 41 chains are now loaded
- [x] ESLint passes
- [x] No breaking changes to existing functionality

## 📊 Impact

- **Before**: 40/41 chains displayed (missing 1 chain)
- **After**: All 41 chains displayed correctly
- **Future-proof**: Will automatically fetch any number of chains as the list grows

<img width="1010" height="103" alt="image" src="https://github.com/user-attachments/assets/0750d84b-4091-4ddb-b61a-3113fa186669" />
