### PR TITLE
chore: Dispatch promotions repo instead of GitLab

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -74,10 +74,21 @@ jobs:
         env:
           BUCKET_NAME: ${{ secrets.AWS_STAGING_BUCKET_NAME }}
           VERSION: ${{ github.event.release.tag_name }}
-      - name: Call script to prepare production deployments 
+      - name: Generate promotions repo token
+        id: promotions_token
         if: (github.event_name == 'release' && github.event.action == 'released')
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.PROMOTIONS_APP_ID }}
+          private-key: ${{ secrets.PROMOTIONS_APP_PRIVATE_KEY }}
+          repositories: ${{ secrets.PROMOTIONS_REPO }}
+          permission-actions: write
+      - name: Call script to prepare production deployments
+        if: (github.event_name == 'release' && github.event.action == 'released')
+        continue-on-error: true
         run: bash ./scripts/github/prepare_production_deployment.sh
         env:
-          PROD_DEPLOYMENT_HOOK_TOKEN: ${{ secrets.PROD_DEPLOYMENT_HOOK_TOKEN }}
-          PROD_DEPLOYMENT_HOOK_URL: ${{ secrets.PROD_DEPLOYMENT_HOOK_URL }}
+          GH_TOKEN: ${{ steps.promotions_token.outputs.token }}
+          PROMOTIONS_REPO: ${{ github.repository_owner }}/${{ secrets.PROMOTIONS_REPO }}
           VERSION_TAG: ${{ github.event.release.tag_name }}

--- a/scripts/github/prepare_production_deployment.sh
+++ b/scripts/github/prepare_production_deployment.sh
@@ -4,14 +4,19 @@ set -ev
 
 # Only:
 # - Tagged commits
-# - Security env variables are available.
-if [ -n "$VERSION_TAG" ] && [ -n "$PROD_DEPLOYMENT_HOOK_TOKEN" ] && [ -n "$PROD_DEPLOYMENT_HOOK_URL" ]
+# - GH_TOKEN and PROMOTIONS_REPO are available.
+if [ -n "$VERSION_TAG" ] && [ -n "$GH_TOKEN" ] && [ -n "$PROMOTIONS_REPO" ]
 then
-  curl --silent --output /dev/null --write-out "%{http_code}" -X POST \
-     -F token="$PROD_DEPLOYMENT_HOOK_TOKEN" \
-     -F ref=master \
-     -F "variables[TRIGGER_RELEASE_COMMIT_TAG]=$VERSION_TAG" \
-      $PROD_DEPLOYMENT_HOOK_URL
+  # --ref is required: without it gh resolves the default branch via GraphQL,
+  # which the app token (actions:write, metadata:read only) is not allowed to do.
+  if ! gh workflow run status-page-production.yml \
+    --repo "$PROMOTIONS_REPO" \
+    --ref main \
+    -f "tag=$VERSION_TAG"
+  then
+    echo "::error::Failed to dispatch production deployment for $VERSION_TAG"
+    exit 1
+  fi
 else
-  echo "[ERROR] Production deployment could not be prepared"
+  echo "::warning::Production deployment could not be prepared: VERSION_TAG, GH_TOKEN or PROMOTIONS_REPO missing"
 fi


### PR DESCRIPTION
## Description
Production releases currently POST a GitLab pipeline-trigger webhook (gitlab.5afe.dev). This swaps the release workflow to dispatch the gated `status-page-production.yml` workflow in `safe-production-promotions` via the `safe-promotions-dispatcher` GitHub App, the same change safe-dashboard made in safe-global/safe-dashboard#271.

## Changes
- `node.yml`: new token-mint step (`actions/create-github-app-token`, SHA-pinned v3.2.0) and the prepare step now passes `GH_TOKEN`/`PROMOTIONS_REPO`; both carry the release-only `if:` since this job also runs staging deploys
- `prepare_production_deployment.sh`: `gh workflow run status-page-production.yml --ref main -f tag=<release tag>` replaces the GitLab curl
- `PROMOTIONS_APP_ID`/`PROMOTIONS_APP_PRIVATE_KEY`/`PROMOTIONS_REPO` secrets are already set; dispatch steps are `continue-on-error` so a promotions outage never blocks the staging artifact upload

## Linear
[CLOUD-978](https://linear.app/safe-global/issue/CLOUD-978)
